### PR TITLE
Use HTTPS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,5 +15,5 @@ SHELL_DOCKER_OPTS ?=    -p 8384:8384
 ## Image tools  (https://github.com/scaleway/image-tools)
 all:	docker-rules.mk
 docker-rules.mk:
-	wget -qO - http://j.mp/scw-builder | bash
+	wget -qO - https://j.mp/scw-builder | bash
 -include docker-rules.mk


### PR DESCRIPTION
When piping the internet to a shell at least use HTTPS.